### PR TITLE
Refactor Snippet + Quotes

### DIFF
--- a/AppBL/GACDBL/ISnippets.cs
+++ b/AppBL/GACDBL/ISnippets.cs
@@ -6,7 +6,7 @@ namespace GACDBL
 {
     public interface ISnippets
     {
-        Task<string> GetRandomQuote();
+        Task<TestMaterial> GetRandomQuote();
         Task<string> GetCodeSnippet(Language language);
     }
 }

--- a/AppBL/GACDModels/TestMaterial.cs
+++ b/AppBL/GACDModels/TestMaterial.cs
@@ -1,0 +1,20 @@
+namespace GACDModels
+{
+    /// <summary>
+    /// This object hold data for a quote. 
+    /// </summary>
+    /// <value></value>
+    public class TestMaterial
+    {
+        public TestMaterial(string content, string author, int length)
+        {
+            this.content = content;
+            this.author = author;
+            this.length = length;
+        }
+
+        public string content { get; set; }
+        public string author { get; set; }
+        public int length { get; set; }
+    }
+}

--- a/AppBL/GACDRest/Controllers/testController.cs
+++ b/AppBL/GACDRest/Controllers/testController.cs
@@ -1,8 +1,10 @@
+using System.Net.Mime;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GACDBL;
+using GACDModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Octokit;
@@ -19,7 +21,7 @@ namespace GACDRest
         }
         [HttpGet]
         [Route("RandomQuote")]
-        public async Task<String> GetRandomQuote()
+        public async Task<TestMaterial> GetRandomQuote()
         {
             return await _snippetsService.GetRandomQuote();
         }


### PR DESCRIPTION
Quotes now return a TestMaterial object with content, author and length. Snippets are still returned as a string. The TestMaterial Class should be used in the future. An IO stream with the snippet material can be parsed to eliminate things nobody wants to type(usings and comments) Rules will be different for each language